### PR TITLE
Fixes bug in sample code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Add to *project.clj* / *build.boot*: `[org.roman01la/citrus "3.0.0"]`
 
 (defmethod control :init-ready [_ [counter]]
   (if-not (nil? counter)
-    {:state counter} ;; init with saved state
+    {:state (js/parseInt counter)} ;; init with saved state
     {:state initial-state})) ;; or with predefined initial state
 
 (defmethod control :inc [_ _ counter]


### PR DESCRIPTION
I've created a sample project and copy-pasted an example from README.
Funny thing happened after page reload: when I press "+" button several times I get "01111" in the value label.

Parsing received value from local-storage fixes this minor inconvenience.