### PR TITLE
Provide both a schedule-fn and release-fn to customize batched updates

### DIFF
--- a/src/citrus/core.cljs
+++ b/src/citrus/core.cljs
@@ -8,7 +8,7 @@
     (citrus/reconciler {:state (atom {})
                         :controllers {:counter counter/control}
                         :effect-handlers {:http effects/http}
-                        :batched-updates f
+                        :batched-updates {:schedule-fn f :release-fn f'}
                         :chunked-updates f})
 
   Arguments
@@ -17,7 +17,8 @@
       state             - app state atom
       controllers       - a hash of state controllers
       effect-handlers   - a hash of effects handlers
-      batched-updates   - a function used to batch reconciler updates, defaults to `js/requestAnimationFrame`
+      batched-updates   - a hash of two functions used to batch reconciler updates, defaults to
+                          `{:schedule-fn js/requestAnimationFrame :release-fn js/cancelAnimationFrame}`
       chunked-updates   - a function used to divide reconciler update into chunks, doesn't used by default
 
   Returned value supports deref, watches and metadata.
@@ -30,7 +31,7 @@
     state
     (volatile! [])
     (volatile! nil)
-    (or batched-updates js/requestAnimationFrame)
+    (or batched-updates {:schedule-fn js/requestAnimationFrame :release-fn js/cancelAnimationFrame})
     chunked-updates
     (:meta options)))
 

--- a/src/citrus/reconciler.cljs
+++ b/src/citrus/reconciler.cljs
@@ -7,11 +7,11 @@
 (defn- clear-queue! [queue]
   (vreset! queue []))
 
-(defn- schedule-update! [schedule! scheduled? f]
+(defn- schedule-update! [{:keys [schedule-fn release-fn]} scheduled? f]
   (when-let [id @scheduled?]
     (vreset! scheduled? nil)
-    (js/cancelAnimationFrame id))
-  (vreset! scheduled? (schedule! f)))
+    (release-fn id))
+  (vreset! scheduled? (schedule-fn f)))
 
 (defprotocol IReconciler
   (dispatch! [this controller event args])


### PR DESCRIPTION
In relation with https://github.com/roman01la/citrus/issues/25

This pull request only provides a way to customize the batch behaviour, it does not alter the default `js/requestAnimationFrame` behaviour.

