### PR TITLE
Add a single watch to the state per reconciler

### DIFF
--- a/src/citrus/reconciler.cljs
+++ b/src/citrus/reconciler.cljs
@@ -19,7 +19,7 @@
   (broadcast! [this event args])
   (broadcast-sync! [this event args]))
 
-(deftype Reconciler [controllers effect-handlers co-effects state queue scheduled? batched-updates chunked-updates meta]
+(deftype Reconciler [controllers effect-handlers co-effects state queue scheduled? batched-updates chunked-updates meta watch-fns]
 
   Object
   (equiv [this other]
@@ -40,14 +40,11 @@
 
   IWatchable
   (-add-watch [this key callback]
-    (add-watch state (list this key)
-      (fn [_ _ oldv newv]
-        (when (not= oldv newv)
-          (callback key this oldv newv))))
+    (vswap! watch-fns assoc key callback)
     this)
 
   (-remove-watch [this key]
-    (remove-watch state (list this key))
+    (vswap! watch-fns dissoc key)
     this)
 
   IHash


### PR DESCRIPTION
Before this patch, each subscription passed to `rum/react` added a watcher
to the state atom of the reconciler through `add-watch`. This means that
every time the atom was `swap!`ed the watch callback was executed, especially
the `(not= oldv newv)`. `not=` can be costly for big/complex enough states.

This patch replaces this mecanism by setting a *single* watch with `add-watch`
on the state per reconciler, at construction time, and registers the watchers
in a simple map. The single watch executes `not=` a single time and executes
the watchers only then, which basically means `rum/request-render`.

For complex enough UI/states it can make a *big* difference in performance.

All tests still pass and no public API has changed.